### PR TITLE
[Issue #1] Quote single quotes in titles

### DIFF
--- a/create_specs.rb
+++ b/create_specs.rb
@@ -78,9 +78,10 @@ class CreateSpecs
 
   def generate_examples_section
     @catalog['data']['resources'].each do |r|
+      title = r['title'].gsub(/'/, "\\\\'")
       @content +=
 "  it {
-    is_expected.to contain_#{r['type'].downcase}('#{r['title']}').with({
+    is_expected.to contain_#{r['type'].downcase}('#{title}').with({
 "
       r['parameters'].each do |k, v|
         unless r['type'] == 'File' and k == 'content'


### PR DESCRIPTION
In a resource title the single quote character needs to be escaped.